### PR TITLE
use Javalin

### DIFF
--- a/src/main/java/com/gctoolkit/glannouncement/RequestHandler.java
+++ b/src/main/java/com/gctoolkit/glannouncement/RequestHandler.java
@@ -18,6 +18,11 @@ public final class RequestHandler implements Router {
         app.get("/glannouncement/list", RequestHandler::processRequest);
 //        app.post("/glannouncement/carousel", RequestHandler::requestKey);
     }
+    public void applyRoutes(Javalin javalin) {
+
+        javalin.get("/glannouncement/list", ctx -> ctx.json(PluginTemplate.getInstance().getConfiguration().announcementItems));
+//        app.post("/glannouncement/carousel", RequestHandler::requestKey);
+    }
     public static void processRequest(Request req, Response res) throws IOException {{
         res.type("application/json");
 

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -1,17 +1,17 @@
 {
   "announcementItems": [
     {
-      "content": "[¹«¸æ]GL×¨ÓÃ¹«¸æ²å¼ş·¢²¼",
+      "content": "[å…¬å‘Š]GLä¸“ç”¨å…¬å‘Šæ’ä»¶å‘å¸ƒ",
       "url": "https://github.com/gc-toolkit/GLAnnounceBackend",
       "time": "08/29"
     },
     {
-      "content": "[»î¶¯]ĞÂ»î¶¯ÒÑ¿ªÆô£¬µã»÷Ç°Íù",
+      "content": "[æ´»åŠ¨]æ–°æ´»åŠ¨å·²å¼€å¯ï¼Œç‚¹å‡»å‰å¾€",
       "url": "https://github.com/gc-toolkit/GLAnnounceBackend",
       "time": "08/29"
     },
     {
-      "content": "[Í¨Öª]·şÎñÆ÷½«ÔÚ9ÔÂ1ÈÕ17-19Ê±½øĞĞÎ¬»¤£¬ÏêÇéµã»÷²é¿´",
+      "content": "[é€šçŸ¥]æœåŠ¡å™¨å°†åœ¨9æœˆ1æ—¥17-19æ—¶è¿›è¡Œç»´æŠ¤ï¼Œè¯¦æƒ…ç‚¹å‡»æŸ¥çœ‹",
       "url": "https://github.com/gc-toolkit/GLAnnounceBackend",
       "time": "08/29"
     }


### PR DESCRIPTION
割草机在这次更新中改了applyRoutes
https://github.com/Grasscutters/Grasscutter/commit/b5bed6ceefe596e2537c2cde0c61f7a27186a855

    void applyRoutes(Express express, Javalin handle);
    void applyRoutes(Javalin javalin);

导致插件报错无法使用
18:48:35 <ERROR:PluginManager> 无法启用插件：GLAnnounceMent
java.lang.AbstractMethodError: Receiver class com.gctoolkit.glannouncement.RequestHandler does not define or inherit an implementation of the resolved method 'abstract void applyRoutes(io.javalin.Javalin)' of interface emu.grasscutter.server.http.Router.
        at emu.grasscutter.server.http.HttpServer.addRouter(HttpServer.java:121)
        at com.gctoolkit.glannouncement.PluginTemplate.onEnable(PluginTemplate.java:92)
        at emu.grasscutter.plugin.PluginManager.lambda$enablePlugins$2(PluginManager.java:202)
        at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:721)
        at emu.grasscutter.plugin.PluginManager.enablePlugins(PluginManager.java:199)
        at emu.grasscutter.Grasscutter.main(Grasscutter.java:160)